### PR TITLE
feat: Use N-API

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -1,10 +1,13 @@
 {
   "targets": [
     {
-      "target_name": "focus-assist",
+      "target_name": "focusassist",
       "sources": [ ],
+      "cflags!": [ "-fno-exceptions" ],
+      "cflags_cc!": [ "-fno-exceptions" ],
+      "defines": [ "NAPI_DISABLE_CPP_EXCEPTIONS" ],
       "include_dirs": [
-        "<!(node -e \"require('nan')\")"
+        "<!@(node -p \"require('node-addon-api').include\")"
       ],
       "conditions": [
         ['OS=="win"', {

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,49 +1,61 @@
-let lib
+let lib;
 
 var Status = {
-    NOT_SUPPORTED: { value: -2, name: "NOT_SUPPORTED" },
-    FAILED: { value: -1, name: "FAILED" },
-    OFF: { value:0, name: "OFF" },
-    PRIORITY_ONLY: { value:1, name: "PRIORITY_ONLY" },
-    ALARMS_ONLY: { value:2, name: "ALARMS_ONLY" }
-  };
+  NOT_SUPPORTED: { value: -2, name: "NOT_SUPPORTED" },
+  FAILED: { value: -1, name: "FAILED" },
+  OFF: { value: 0, name: "OFF" },
+  PRIORITY_ONLY: { value: 1, name: "PRIORITY_ONLY" },
+  ALARMS_ONLY: { value: 2, name: "ALARMS_ONLY" },
+};
 
-  var Priority = {
-    NOT_SUPPORTED: { value: -2, name: "NOT_SUPPORTED" },
-    FAILED: { value: -1, name: "FAILED" },
-    NO: { value:0, name: "NO" },
-    YES: { value:1, name: "YES" },
-  };
+var Priority = {
+  NOT_SUPPORTED: { value: -2, name: "NOT_SUPPORTED" },
+  FAILED: { value: -1, name: "FAILED" },
+  NO: { value: 0, name: "NO" },
+  YES: { value: 1, name: "YES" },
+};
 
-function getFocusAssist () {
-  if (process.platform !== 'win32') {
-    throw new Error('windows-focus-assist works only on Windows')
+function getFocusAssist() {
+  if (process.platform !== "win32") {
+    throw new Error("windows-focus-assist works only on Windows");
   }
 
-  lib = lib || require('bindings')('focus-assist')
-  switch (lib.GetFocusAssist()){
-      case -2 : return Status.NOT_SUPPORTED;
-      case -1 : return Status.FAILED;
-      case 0 : return Status.OFF;
-      case 1 : return Status.PRIORITY_ONLY;
-      case 2 : return Status.ALARMS_ONLY;
-      default : return Status.UNKNOWN;
-  }
-}
+  lib = lib || require("bindings")("focusassist");
 
-function isPriority (appUserModelId) {
-  if (process.platform !== 'win32') {
-    throw new Error('windows-focus-assist works only on Windows')
-  }
-
-  lib = lib || require('bindings')('focus-assist')
-  switch (lib.IsPriority(appUserModelId)){
-      case -2 : return Priority.NOT_SUPPORTED;
-      case -1 : return Priority.FAILED;
-      case 0 : return Priority.NO;
-      case 1 : return Priority.YES;
-      default : return Status.UNKNOWN;
+  switch (lib.getFocusAssist()) {
+    case -2:
+      return Status.NOT_SUPPORTED;
+    case -1:
+      return Status.FAILED;
+    case 0:
+      return Status.OFF;
+    case 1:
+      return Status.PRIORITY_ONLY;
+    case 2:
+      return Status.ALARMS_ONLY;
+    default:
+      return Status.UNKNOWN;
   }
 }
 
-module.exports = { getFocusAssist: getFocusAssist, isPriority: isPriority }
+function isPriority(appUserModelId) {
+  if (process.platform !== "win32") {
+    throw new Error("windows-focus-assist works only on Windows");
+  }
+
+  lib = lib || require("bindings")("focusassist");
+  switch (lib.isPriority(appUserModelId)) {
+    case -2:
+      return Priority.NOT_SUPPORTED;
+    case -1:
+      return Priority.FAILED;
+    case 0:
+      return Priority.NO;
+    case 1:
+      return Priority.YES;
+    default:
+      return Status.UNKNOWN;
+  }
+}
+
+module.exports = { getFocusAssist, isPriority };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "windows-focus-assist",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "description": "Gets the Focus Assist status in Windows 10 CU or later.",
   "main": "lib/index.js",
   "scripts": {


### PR DESCRIPTION
Updated to use N-API instead of NAN. 

My main goal here was to fix an issue whereby the NAN module was not self-registering, leading to an issue in Electron apps. Specifically, I was hitting the "Module did not self-register" errors, which I was able to fix by using `electron-rebuild` locally, but did not have any luck in a packaged app (at least with `electron-builder`). 

After updating to N-API, that issue is resolved. 