### PR TITLE
build: enable C++20

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -13,7 +13,20 @@
         ['OS=="win"', {
           "sources": [ "lib/focus-assist.cc", "lib/quiethours.idl", "lib/quiethours_h.h", "lib/quiethours_i.c" ],
         }]
-      ]
+      ],
+      "configurations": {
+        "Release": {
+          "msvs_settings": {
+            "VCCLCompilerTool": {
+              "AdditionalOptions": ["/std:c++20"],
+              "AdditionalOptions!": ["-std:c++17"],
+            }
+          }
+        },
+        "Debug": {
+          "inherit_from": ["Release"],
+        }
+      }
     }
   ]
 }

--- a/lib/focus-assist.cc
+++ b/lib/focus-assist.cc
@@ -23,9 +23,9 @@ enum PRIORITY_RESULT
 
   #define NT_SUCCESS_STATUS(Status) (((NTSTATUS)(Status)) >= 0)
 
-  const LPWSTR ALARMS_ONLY_ID = L"Microsoft.QuietHoursProfile.AlarmsOnly";
-  const LPWSTR PRIORITY_ONLY_ID = L"Microsoft.QuietHoursProfile.PriorityOnly";
-  const LPWSTR UNRESTRICTED_ID = L"Microsoft.QuietHoursProfile.Unrestricted";
+  const wchar_t* ALARMS_ONLY_ID = L"Microsoft.QuietHoursProfile.AlarmsOnly";
+  const wchar_t* PRIORITY_ONLY_ID = L"Microsoft.QuietHoursProfile.PriorityOnly";
+  const wchar_t* UNRESTRICTED_ID = L"Microsoft.QuietHoursProfile.Unrestricted";
 
   typedef struct _WNF_STATE_NAME
   {
@@ -124,9 +124,12 @@ enum PRIORITY_RESULT
     CComHeapPtr<wchar_t> profileId;
     if (IsFailed(quietHoursSettings->get_UserSelectedProfile(&profileId))) { return API_RESULT::FAILED; }
 
-    const LPWSTR profileIdWS = static_cast<LPWSTR>(profileId);
+
+    std::wstring priorityOnlyIdWS(PRIORITY_ONLY_ID);
+    LPWSTR lpPriorityOnlyIdWS = &priorityOnlyIdWS[0];
+
     CComPtr<IQuietHoursProfile> profile;
-    if (IsFailed(quietHoursSettings->GetProfile(PRIORITY_ONLY_ID, &profile))) { return API_RESULT::FAILED; }
+    if (IsFailed(quietHoursSettings->GetProfile(lpPriorityOnlyIdWS, &profile))) { return API_RESULT::FAILED; }
 
     uint32_t count = 0;
     {


### PR DESCRIPTION
Enables C++20 and fixes the wide string errors that appeared as a result. This allows for compatibility with Electron v33 due to Chromium requiring native code using C++20 standards.